### PR TITLE
Added a .set option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,12 @@ var p = Progress.create({
   total: 100
 })
 
-// Update the total percentage
+// Add to the total percentage so far
 p.step(50)
+
+// Set the total percentage so far
+p.set(75)
+
 ```
 
 Output Example:

--- a/lib/progress.js
+++ b/lib/progress.js
@@ -85,7 +85,13 @@ module.exports = {
             this.progress += size;
             this.render();
           }
-        }
+        },
+				set: {
+        	value(precent){
+	          this.progress = precent;
+	          this.render();
+	        }
+				}
       })
       .init(options);
   }

--- a/lib/progress.js
+++ b/lib/progress.js
@@ -86,12 +86,12 @@ module.exports = {
             this.render();
           }
         },
-				set: {
-        	value(precent){
-	          this.progress = precent;
-	          this.render();
-	        }
-				}
+        set: {
+          value(precent){
+            this.progress = precent;
+            this.render();
+          }
+        }
       })
       .init(options);
   }


### PR DESCRIPTION
I noticed `.step` added when I want to just set the total precent progressed so far. The word update in the readme made me think it was setting it, but instead it adds it.

It seems like with the step method I’d have to do a lot of extra math when I’m already getting a precent I’d just want to set. 

So a small little fix as I think most work by setting instead of adding.

Otherwise this is a very nice module
